### PR TITLE
Enhance handling for digit characters

### DIFF
--- a/src/commonMain/kotlin/net/pearx/kasechange/CharUtils.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/CharUtils.kt
@@ -9,3 +9,4 @@ package net.pearx.kasechange
 
 internal expect fun Char.isUpperCasePlatform(): Boolean
 internal expect fun Char.isLowerCasePlatform(): Boolean
+internal expect fun Char.isDigitPlatform(): Boolean

--- a/src/commonMain/kotlin/net/pearx/kasechange/splitter/WordSplitter.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/splitter/WordSplitter.kt
@@ -7,6 +7,7 @@
 
 package net.pearx.kasechange.splitter
 
+import net.pearx.kasechange.isDigitPlatform
 import net.pearx.kasechange.isLowerCasePlatform
 import net.pearx.kasechange.isUpperCasePlatform
 
@@ -14,17 +15,21 @@ private val BOUNDARIES = arrayOf(' ', '-', '_', '.')
 
 private fun StringBuilder.toStringAndClear() = toString().also { clear() }
 
+private fun Char.isDigitOrUpperCase(): Boolean = this.isUpperCasePlatform() || this.isDigitPlatform()
+
 /**
  * Splits a string to multiple words by using the following rules:
  * - All ' ', '-', '_', '.' characters are considered word boundaries.
  * - If a lowercase character is followed by an uppercase character, a word boundary is considered to be prior to the uppercase character.
  * - If multiple uppercase characters are followed by a lowercase character, a word boundary is considered to be prior to the last uppercase character.
+ * - Digit characters handle same as uppercase characters.
  *
  * Examples:
  * - XMLBufferedReader => XML|Buffered|Reader
  * - newFile => new|File
  * - net.pearx.lib => net|pearx|lib
  * - NewDataClass => New|Data|Class
+ * - UInt32Value => U|Int|32|Value
  */
 fun String.splitToWords(): List<String> = mutableListOf<String>().also { list ->
     val word = StringBuilder()
@@ -34,9 +39,9 @@ fun String.splitToWords(): List<String> = mutableListOf<String>().also { list ->
             list.add(word.toStringAndClear())
         }
         else {
-            if (char.isUpperCasePlatform()) {
+            if (char.isDigitOrUpperCase()) {
                 if ((index > 0 && this[index - 1].isLowerCasePlatform()) ||
-                    (index > 0 && index < length - 1 && this[index - 1].isUpperCasePlatform() && this[index + 1].isLowerCasePlatform())) {
+                    (index > 0 && index < length - 1 && this[index - 1].isDigitOrUpperCase() && this[index + 1].isLowerCasePlatform())) {
                     list.add(word.toStringAndClear())
                 }
             }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/ComplexTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/ComplexTest.kt
@@ -7,63 +7,73 @@
 
 package net.pearx.kasechange.test
 
-import net.pearx.kasechange.*
+import net.pearx.kasechange.toCamelCase
+import net.pearx.kasechange.toDotCase
+import net.pearx.kasechange.toKebabCase
+import net.pearx.kasechange.toLowerSpaceCase
+import net.pearx.kasechange.toPascalCase
+import net.pearx.kasechange.toScreamingSnakeCase
+import net.pearx.kasechange.toSnakeCase
+import net.pearx.kasechange.toTitleCase
+import net.pearx.kasechange.toTrainCase
+import net.pearx.kasechange.toUpperDotCase
+import net.pearx.kasechange.toUpperSpaceCase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ComplexTest {
     @Test
     fun testCamel() {
-        assertEquals("someString", "Some String".toCamelCase())
+        assertEquals("someStringWith123Numbers", "Some String With 123 Numbers".toCamelCase())
     }
 
     @Test
     fun testPascal() {
-        assertEquals("SomeString", "Some String".toPascalCase())
+        assertEquals("SomeStringWith123Numbers", "Some String With 123 Numbers".toPascalCase())
     }
 
     @Test
     fun testSnake() {
-        assertEquals("some_string", "Some String".toSnakeCase())
+        assertEquals("some_string_with_123_numbers", "Some String With 123 Numbers".toSnakeCase())
     }
 
     @Test
     fun testScreamingSnake() {
-        assertEquals("SOME_STRING", "Some String".toScreamingSnakeCase())
+        assertEquals("SOME_STRING_WITH_123_NUMBERS", "Some String With 123 Numbers".toScreamingSnakeCase())
     }
 
     @Test
     fun testKebab() {
-        assertEquals("some-string", "Some String".toKebabCase())
+        assertEquals("some-string-with-123-numbers", "Some String With 123 Numbers".toKebabCase())
     }
 
     @Test
     fun testTrain() {
-        assertEquals("SOME-STRING", "Some String".toTrainCase())
+        assertEquals("SOME-STRING-WITH-123-NUMBERS", "Some String With 123 Numbers".toTrainCase())
     }
 
     @Test
     fun testLowerSpace() {
-        assertEquals("some string", "Some String".toLowerSpaceCase())
+        assertEquals("some string with 123 numbers", "Some String With 123 Numbers".toLowerSpaceCase())
     }
 
     @Test
     fun testUpperSpace() {
-        assertEquals("SOME STRING", "Some String".toUpperSpaceCase())
+        assertEquals("SOME STRING WITH 123 NUMBERS", "Some String With 123 Numbers".toUpperSpaceCase())
     }
 
     @Test
     fun testTitle() {
-        assertEquals("Some String", "some string".toTitleCase())
+        assertEquals("Some String With 123 Numbers", "some string with 123 numbers".toTitleCase())
     }
 
     @Test
     fun testDot() {
-        assertEquals("some.string", "Some String".toDotCase())
+        assertEquals("some.string.with.123.numbers", "Some String With 123 Numbers".toDotCase())
     }
 
     @Test
     fun testDotUpper() {
-        assertEquals("SOME.STRING", "Some String".toUpperDotCase())
+        assertEquals("SOME.STRING.WITH.123.NUMBERS", "Some String With 123 Numbers".toUpperDotCase())
     }
 }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/SplitToWordsTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/SplitToWordsTest.kt
@@ -30,5 +30,6 @@ class SplitToWordsTest {
         assertEquals(listOf("XMLHTTP"), "XMLHTTP".splitToWords())
         assertEquals(listOf("S", "Class", "C"), "SClassC".splitToWords())
         assertEquals(listOf("XML", "Http", "Request", "JSON"), "XMLHttpRequestJSON".splitToWords())
+        assertEquals(listOf("U", "Int", "32", "Value"), "UInt32Value".splitToWords())
     }
 }

--- a/src/jsMain/kotlin/net/pearx/kasechange/CharUtils.kt
+++ b/src/jsMain/kotlin/net/pearx/kasechange/CharUtils.kt
@@ -10,3 +10,5 @@ package net.pearx.kasechange
 internal actual fun Char.isUpperCasePlatform(): Boolean = toUpperCase() == this && toLowerCase() != this
 
 internal actual fun Char.isLowerCasePlatform(): Boolean = toLowerCase() == this && toUpperCase() != this
+
+internal actual fun Char.isDigitPlatform(): Boolean = this in '0'..'9'

--- a/src/jvmMain/kotlin/net/pearx/kasechange/CharUtils.kt
+++ b/src/jvmMain/kotlin/net/pearx/kasechange/CharUtils.kt
@@ -11,3 +11,5 @@ package net.pearx.kasechange
 internal actual fun Char.isUpperCasePlatform(): Boolean = isUpperCase()
 
 internal actual fun Char.isLowerCasePlatform(): Boolean = isLowerCase()
+
+internal actual fun Char.isDigitPlatform(): Boolean = isDigit()


### PR DESCRIPTION
## Description
This PR enhances digit characters handling, and it handles digit characters same as uppercase characters.
There are some samples:
```
before:
UInt32Value => U|Int32Value

after:
UInt32Value => U|Int|32|Value
```