### PR TITLE
Introducing CaseFormatter abstraction to allow for extensibility without needing to change the library

### DIFF
--- a/src/commonMain/kotlin/net/pearx/kasechange/CaseFormat.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/CaseFormat.kt
@@ -8,74 +8,32 @@
 package net.pearx.kasechange
 
 import net.pearx.kasechange.splitter.splitToWords
+import net.pearx.kasechange.ConfigCaseFormatter.Config
 
 /**
  * An enumeration that represents a case format that can be used to join a collection of words into one string.
  */
-enum class CaseFormat(private val wordUppercase: Boolean, private val wordSplitter: Char?, private val wordCapitalize: Boolean = false, private val firstWordCapitalize: Boolean = false) {
+enum class CaseFormat(val config: Config) : CaseFormatter by ConfigCaseFormatter(config) {
     /** SCREAMING_SNAKE_CASE */
-    UPPER_UNDERSCORE(true, '_'),
+    UPPER_UNDERSCORE(Config(true, "_")),
     /** snake_case */
-    LOWER_UNDERSCORE(false, '_'),
+    LOWER_UNDERSCORE(Config(false, "_")),
     /** PascalCase */
-    CAPITALIZED_CAMEL(false, null, true, true),
+    CAPITALIZED_CAMEL(Config(false, null, true, true)),
     /** camelCase */
-    CAMEL(false, null, true, false),
+    CAMEL(Config(false, null, true, false)),
     /** TRAIN-CASE */
-    UPPER_HYPHEN(true, '-'),
+    UPPER_HYPHEN(Config(true, "-")),
     /** kebab-case */
-    LOWER_HYPHEN(false, '-'),
+    LOWER_HYPHEN(Config(false, "-")),
     /** UPPER SPACE CASE */
-    UPPER_SPACE(true, ' '),
+    UPPER_SPACE(Config(true, " ")),
     /** Title Case */
-    CAPITALIZED_SPACE(false, ' ', true, true),
+    CAPITALIZED_SPACE(Config(false, " ", true, true)),
     /** lower space case */
-    LOWER_SPACE(false, ' '),
+    LOWER_SPACE(Config(false, " ")),
     /** UPPER.DOT.CASE */
-    UPPER_DOT(true, '.'),
+    UPPER_DOT(Config(true, ".")),
     /** dot.case */
-    LOWER_DOT(false, '.');
-
-    /**
-     * Joins [words] using this case format, appending the result to [appendable]
-     */
-    fun formatTo(appendable: Appendable, words: Iterable<String>) {
-        appendable.apply {
-            for ((index, word) in words.withIndex()) {
-                if (wordSplitter != null && index != 0)
-                    append(wordSplitter)
-                append(when {
-                    wordUppercase -> word.toUpperCase()
-                    index == 0 -> {
-                        when {
-                            firstWordCapitalize -> word.toLowerCase().capitalize()
-                            else -> word.toLowerCase()
-                        }
-                    }
-                    wordCapitalize -> word.toLowerCase().capitalize()
-                    else -> word.toLowerCase()
-                })
-            }
-        }
-    }
-
-    /**
-     * Joins [words] using this case format, appending the result to [appendable]
-     */
-    fun formatTo(appendable: Appendable, vararg words: String) = formatTo(appendable, words.asIterable())
-
-    /**
-     * Joins [words] using this case format and returns the result.
-     */
-    fun format(words: Iterable<String>): String = StringBuilder().also { formatTo(it, words) }.toString()
-
-    /**
-     * Joins [words] using this case format and returns the result.
-     */
-    fun format(vararg words: String) = format(words.asIterable())
-
-    /**
-     * Converts a string to this [CaseFormat] using the word splitting rules defined in [splitToWords]
-     */
-    fun format(string: String) = format(string.splitToWords())
+    LOWER_DOT(Config(false, "."));
 }

--- a/src/commonMain/kotlin/net/pearx/kasechange/CaseFormatter.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/CaseFormatter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2019, PearX Team
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package net.pearx.kasechange
+
+import net.pearx.kasechange.splitter.splitToWords
+
+/**
+ * An interface that defines a case formatter that can be used to join a collection of words into one string.
+ */
+interface CaseFormatter {
+
+    /**
+     * Joins [words], appending the result to [appendable]
+     */
+    fun formatTo(appendable: Appendable, words: Iterable<String>)
+
+    /**
+     * Joins [words], appending the result to [appendable]
+     */
+    fun formatTo(appendable: Appendable, vararg words: String) = formatTo(appendable, words.asIterable())
+
+    /**
+     * Joins [words] and returns the result.
+     */
+    fun format(words: Iterable<String>): String = StringBuilder().also { formatTo(it, words) }.toString()
+
+    /**
+     * Joins [words] and returns the result.
+     */
+    fun format(vararg words: String) = format(words.asIterable())
+
+    /**
+     * Converts a string to the case format of the formatter using the word splitting rules defined in [splitToWords]
+     */
+    fun format(string: String) = format(string.splitToWords())
+}

--- a/src/commonMain/kotlin/net/pearx/kasechange/ConfigCaseFormatter.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/ConfigCaseFormatter.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2019, PearX Team
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package net.pearx.kasechange
+
+import net.pearx.kasechange.splitter.splitToWords
+
+/**
+ * An interface that defines a case formatter that can be used to join a collection of words into one string.
+ */
+class ConfigCaseFormatter(private val config: Config) : CaseFormatter {
+
+    data class Config(val wordUppercase: Boolean, val wordSplitter: String?, val wordCapitalize: Boolean = false, val firstWordCapitalize: Boolean = false)
+
+    /**
+     * Joins [words], appending the result to [appendable]
+     */
+    override fun formatTo(appendable: Appendable, words: Iterable<String>) {
+        with(config) {
+            appendable.apply {
+                for ((index, word) in words.withIndex()) {
+                    if (wordSplitter != null && index != 0)
+                        append(wordSplitter)
+                    append(when {
+                        wordUppercase -> word.toUpperCase()
+                        index == 0 -> {
+                            when {
+                                firstWordCapitalize -> word.toLowerCase().capitalize()
+                                else -> word.toLowerCase()
+                            }
+                        }
+                        wordCapitalize -> word.toLowerCase().capitalize()
+                        else -> word.toLowerCase()
+                    })
+                }
+            }
+        }
+    }
+
+}

--- a/src/commonMain/kotlin/net/pearx/kasechange/StringExtensions.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/StringExtensions.kt
@@ -12,6 +12,11 @@ package net.pearx.kasechange
  */
 fun String.toCase(caseFormat: CaseFormat) = caseFormat.format(this)
 
+/**
+ * Converts a string using the specific [caseFormatConfig] using the word splitting rules defined in [splitToWords].
+ */
+fun String.toCase(caseFormatConfig: ConfigCaseFormatter.Config) = ConfigCaseFormatter(caseFormatConfig).format(this)
+
 /** Converts a string to SCREAMING_SNAKE_CASE using the word splitting rules defined in [splitToWords]. */
 fun String.toScreamingSnakeCase() = toCase(CaseFormat.UPPER_UNDERSCORE)
 /** Converts a string to snake_case using the word splitting rules defined in [splitToWords]. */

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/CaseFormatTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/CaseFormatTest.kt
@@ -8,6 +8,8 @@
 package net.pearx.kasechange.test
 
 import net.pearx.kasechange.CaseFormat
+import net.pearx.kasechange.CaseFormatter
+import net.pearx.kasechange.ConfigCaseFormatter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -65,5 +67,10 @@ class CaseFormatTest {
     @Test
     fun testDotUpper() {
         assertEquals("DOT.CASE.IS.FUN", CaseFormat.UPPER_DOT.format("dot", "Case", "is", "FUN"))
+    }
+
+    @Test
+    fun testConfig() {
+        assertEquals("Config..Allows..More..Options", ConfigCaseFormatter(ConfigCaseFormatter.Config(false, "..", true, true)).format("config", "Allows", "more", "OPTIONS"))
     }
 }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/ComplexTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/ComplexTest.kt
@@ -8,6 +8,7 @@
 package net.pearx.kasechange.test
 
 import net.pearx.kasechange.toCamelCase
+import net.pearx.kasechange.toCase
 import net.pearx.kasechange.toDotCase
 import net.pearx.kasechange.toKebabCase
 import net.pearx.kasechange.toLowerSpaceCase
@@ -18,6 +19,7 @@ import net.pearx.kasechange.toTitleCase
 import net.pearx.kasechange.toTrainCase
 import net.pearx.kasechange.toUpperDotCase
 import net.pearx.kasechange.toUpperSpaceCase
+import net.pearx.kasechange.ConfigCaseFormatter.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -75,5 +77,10 @@ class ComplexTest {
     @Test
     fun testDotUpper() {
         assertEquals("SOME.STRING.WITH.123.NUMBERS", "Some String With 123 Numbers".toUpperDotCase())
+    }
+
+    @Test
+    fun testConfig() {
+        assertEquals("Some..String..With..123..Numbers", "Some String With 123 Numbers".toCase(Config(false, "..", true, true)))
     }
 }


### PR DESCRIPTION
Background for the reason this was raised can be found in https://github.com/pearxteam/kasechange/issues/3