### PR TITLE
Adding option to ignore digits when splitting words

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -50,5 +50,8 @@ Multiplatform Kotlin library to convert strings between various case formats
 ```
  - Splitting a string into words:
 ```kotlin
- "XMLExtendedParser".splitToWords() // [XML, Extended, Parser]
+ "XMLExtended1Parser".splitToWords() // [XML, Extended, 1, Parser]
+```
+```kotlin
+ "XMLExtended1Parser".splitToWords(digitsAsWordBoundaries = false) // [XML, Extended1, Parser]
 ```

--- a/src/commonMain/kotlin/net/pearx/kasechange/splitter/WordSplitter.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/splitter/WordSplitter.kt
@@ -15,23 +15,23 @@ private val BOUNDARIES = arrayOf(' ', '-', '_', '.')
 
 private fun StringBuilder.toStringAndClear() = toString().also { clear() }
 
-private fun Char.isDigitOrUpperCase(digitsAsUppercaseChars: Boolean): Boolean = this.isUpperCasePlatform() || (digitsAsUppercaseChars && this.isDigitPlatform())
+private fun Char.isDigitOrUpperCase(digitsAsWordBoundaries: Boolean): Boolean = this.isUpperCasePlatform() || (digitsAsWordBoundaries && this.isDigitPlatform())
 
 /**
  * Splits a string to multiple words by using the following rules:
  * - All ' ', '-', '_', '.' characters are considered word boundaries.
  * - If a lowercase character is followed by an uppercase character, a word boundary is considered to be prior to the uppercase character.
  * - If multiple uppercase characters are followed by a lowercase character, a word boundary is considered to be prior to the last uppercase character.
- * - Digit characters handle same as uppercase characters if [digitsAsUppercaseChars] is true.
+ * - Digit characters handle same as uppercase characters if [digitsAsWordBoundaries] is true.
  *
  * Examples:
  * - XMLBufferedReader => XML|Buffered|Reader
  * - newFile => new|File
  * - net.pearx.lib => net|pearx|lib
  * - NewDataClass => New|Data|Class
- * - UInt32Value => U|Int|32|Value (if [digitsAsUppercaseChars] is true)
+ * - UInt32Value => U|Int|32|Value (if [digitsAsWordBoundaries] is true)
  */
-fun String.splitToWords(digitsAsUppercaseChars: Boolean = true): List<String> {
+fun String.splitToWords(digitsAsWordBoundaries: Boolean = true): List<String> {
     val list = mutableListOf<String>()
     val word = StringBuilder()
     for (index in 0 until length) {
@@ -40,7 +40,7 @@ fun String.splitToWords(digitsAsUppercaseChars: Boolean = true): List<String> {
             list.add(word.toStringAndClear())
         }
         else {
-            if (char.isDigitOrUpperCase(digitsAsUppercaseChars)) {
+            if (char.isDigitOrUpperCase(digitsAsWordBoundaries)) {
                 val hasPrev = index > 0
                 val hasNext = index < length - 1
                 val prevLowerCase = hasPrev && this[index - 1].isLowerCasePlatform()

--- a/src/commonMain/kotlin/net/pearx/kasechange/splitter/WordSplitter.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/splitter/WordSplitter.kt
@@ -15,23 +15,23 @@ private val BOUNDARIES = arrayOf(' ', '-', '_', '.')
 
 private fun StringBuilder.toStringAndClear() = toString().also { clear() }
 
-private fun Char.isDigitOrUpperCase(): Boolean = this.isUpperCasePlatform() || this.isDigitPlatform()
+private fun Char.isDigitOrUpperCase(digitsAsUppercaseChars: Boolean): Boolean = this.isUpperCasePlatform() || (digitsAsUppercaseChars && this.isDigitPlatform())
 
 /**
  * Splits a string to multiple words by using the following rules:
  * - All ' ', '-', '_', '.' characters are considered word boundaries.
  * - If a lowercase character is followed by an uppercase character, a word boundary is considered to be prior to the uppercase character.
  * - If multiple uppercase characters are followed by a lowercase character, a word boundary is considered to be prior to the last uppercase character.
- * - Digit characters handle same as uppercase characters.
+ * - Digit characters handle same as uppercase characters if [digitsAsUppercaseChars] is true.
  *
  * Examples:
  * - XMLBufferedReader => XML|Buffered|Reader
  * - newFile => new|File
  * - net.pearx.lib => net|pearx|lib
  * - NewDataClass => New|Data|Class
- * - UInt32Value => U|Int|32|Value
+ * - UInt32Value => U|Int|32|Value (if [digitsAsUppercaseChars] is true)
  */
-fun String.splitToWords(): List<String> {
+fun String.splitToWords(digitsAsUppercaseChars: Boolean = true): List<String> {
     val list = mutableListOf<String>()
     val word = StringBuilder()
     for (index in 0 until length) {
@@ -40,11 +40,11 @@ fun String.splitToWords(): List<String> {
             list.add(word.toStringAndClear())
         }
         else {
-            if (char.isDigitOrUpperCase()) {
+            if (char.isDigitOrUpperCase(digitsAsUppercaseChars)) {
                 val hasPrev = index > 0
                 val hasNext = index < length - 1
                 val prevLowerCase = hasPrev && this[index - 1].isLowerCasePlatform()
-                val prevDigitUpperCase = hasPrev && this[index - 1].isDigitOrUpperCase()
+                val prevDigitUpperCase = hasPrev && this[index - 1].isDigitOrUpperCase(true)
                 val nextLowerCase = hasNext && this[index + 1].isLowerCasePlatform()
                 if (prevLowerCase || (prevDigitUpperCase && nextLowerCase)) {
                     list.add(word.toStringAndClear())

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/SplitToWordsTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/SplitToWordsTest.kt
@@ -31,5 +31,7 @@ class SplitToWordsTest {
         assertEquals(listOf("S", "Class", "C"), "SClassC".splitToWords())
         assertEquals(listOf("XML", "Http", "Request", "JSON"), "XMLHttpRequestJSON".splitToWords())
         assertEquals(listOf("U", "Int", "32", "Value"), "UInt32Value".splitToWords())
+        assertEquals(listOf("U", "Int32", "Value"), "UInt32Value".splitToWords(digitsAsUppercaseChars = false))
+        assertEquals(listOf("U", "Int32value"), "UInt32value".splitToWords(digitsAsUppercaseChars = false))
     }
 }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/SplitToWordsTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/SplitToWordsTest.kt
@@ -31,7 +31,7 @@ class SplitToWordsTest {
         assertEquals(listOf("S", "Class", "C"), "SClassC".splitToWords())
         assertEquals(listOf("XML", "Http", "Request", "JSON"), "XMLHttpRequestJSON".splitToWords())
         assertEquals(listOf("U", "Int", "32", "Value"), "UInt32Value".splitToWords())
-        assertEquals(listOf("U", "Int32", "Value"), "UInt32Value".splitToWords(digitsAsUppercaseChars = false))
-        assertEquals(listOf("U", "Int32value"), "UInt32value".splitToWords(digitsAsUppercaseChars = false))
+        assertEquals(listOf("U", "Int32", "Value"), "UInt32Value".splitToWords(digitsAsWordBoundaries = false))
+        assertEquals(listOf("U", "Int32value"), "UInt32value".splitToWords(digitsAsWordBoundaries = false))
     }
 }


### PR DESCRIPTION
This will help maintain behaviour of previous versions of the library should the clients need it