### PR TITLE
Add sentence case format

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,7 @@ Multiplatform Kotlin library to convert strings between various case formats
 - kebab-case
 - UPPER SPACE CASE
 - Title Case
+- Sentence case
 - lower space case
 - UPPER.DOT.CASE
 - dot.case

--- a/src/commonMain/kotlin/net/pearx/kasechange/CaseFormat.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/CaseFormat.kt
@@ -34,6 +34,8 @@ enum class CaseFormat(caseFormatterConfig: CaseFormatterConfig, wordSplitterConf
     UPPER_SPACE(CaseFormatterConfig(true, " "), WordSplitterConfig(setOf(' '))),
     /** Title Case */
     CAPITALIZED_SPACE(CaseFormatterConfig(false, " ", wordCapitalize = true, firstWordCapitalize = true), WordSplitterConfig(setOf(' '))),
+    /** Sentence case */
+    SENTENCE_SPACE(CaseFormatterConfig(false, " ", wordCapitalize = false, firstWordCapitalize = true), WordSplitterConfig(setOf(' '))),
     /** lower space case */
     LOWER_SPACE(CaseFormatterConfig(false, " "), WordSplitterConfig(setOf(' '))),
     /** UPPER.DOT.CASE */

--- a/src/commonMain/kotlin/net/pearx/kasechange/StringExtensions.kt
+++ b/src/commonMain/kotlin/net/pearx/kasechange/StringExtensions.kt
@@ -54,6 +54,9 @@ fun String.toUpperSpaceCase(from: WordSplitter = universalWordSplitter()) = toCa
 /** Returns a copy of this string converted to Title Case by splitting it into multiple words using [specified][from] [WordSplitter] and joining them using [CaseFormat.CAPITALIZED_SPACE].. */
 fun String.toTitleCase(from: WordSplitter = universalWordSplitter()) = toCase(CaseFormat.CAPITALIZED_SPACE, from)
 
+/** Returns a copy of this string converted to Sentence case by splitting it into multiple words using [specified][from] [WordSplitter] and joining them using [CaseFormat.SENTENCE_SPACE].. */
+fun String.toSentenceCase(from: WordSplitter = universalWordSplitter()) = toCase(CaseFormat.SENTENCE_SPACE, from)
+
 /** Returns a copy of this string converted to lower space case by splitting it into multiple words using [specified][from] [WordSplitter] and joining them using [CaseFormat.LOWER_SPACE].. */
 fun String.toLowerSpaceCase(from: WordSplitter = universalWordSplitter()) = toCase(CaseFormat.LOWER_SPACE, from)
 

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/CaseFormatterTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/CaseFormatterTest.kt
@@ -62,6 +62,11 @@ class CaseFormatterTest {
     }
 
     @Test
+    fun testSentence() {
+        assertEquals("Xml http request v2 updated", CaseFormat.SENTENCE_SPACE.format("XmL", "http", "reQuEST", "v2", "Updated"))
+    }
+
+    @Test
     fun testDot() {
         assertEquals("xml.http.request.v2.updated", CaseFormat.LOWER_DOT.format("XML", "http", "reQuEST", "V2", "Updated"))
     }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/ComplexTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/ComplexTest.kt
@@ -60,6 +60,11 @@ class ComplexTest {
     }
 
     @Test
+    fun testSentence() {
+        assertEquals("Xml http request v2 updated", "xml_http_request_v2_updated".toSentenceCase(CaseFormat.LOWER_UNDERSCORE))
+    }
+
+    @Test
     fun testDot() {
         assertEquals("xml.http.request.v2.updated", "xml_http_request_v2_updated".toDotCase(CaseFormat.LOWER_UNDERSCORE))
     }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/UniversalWordSplitter2Test.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/UniversalWordSplitter2Test.kt
@@ -59,6 +59,11 @@ class UniversalWordSplitter2Test {
     }
 
     @Test
+    fun testSentence() {
+        assertEquals(listOf("Xml", "http", "request", "v2", "updated"), "Xml http request v2 updated".splitToWords(universalWordSplitter(false)))
+    }
+
+    @Test
     fun testDot() {
         assertEquals(listOf("xml", "http", "request", "v2", "updated"), "xml.http.request.v2.updated".splitToWords(universalWordSplitter(false)))
     }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/UniversalWordSplitterTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/UniversalWordSplitterTest.kt
@@ -58,6 +58,11 @@ class UniversalWordSplitterTest {
     }
 
     @Test
+    fun testSentence() {
+        assertEquals(listOf("Xml", "request", "v", "2", "updated"), "Xml request v2 updated".splitToWords())
+    }
+
+    @Test
     fun testDot() {
         assertEquals(listOf("xml", "request", "V2", "updated"), "xml.request.V2.updated".splitToWords())
     }

--- a/src/commonTest/kotlin/net/pearx/kasechange/test/WordSplitterTest.kt
+++ b/src/commonTest/kotlin/net/pearx/kasechange/test/WordSplitterTest.kt
@@ -60,6 +60,11 @@ class WordSplitterTest {
     }
 
     @Test
+    fun testSentence() {
+        assertEquals(listOf("Xml", "request", "v2", "updated"), "Xml request v2 updated".splitToWords(CaseFormat.CAPITALIZED_SPACE))
+    }
+
+    @Test
     fun testDot() {
         assertEquals(listOf("xml", "request", "v2", "updated"), "xml.request.v2.updated".splitToWords(CaseFormat.LOWER_DOT))
     }


### PR DESCRIPTION
Alternative to [kotlin.text.capitalize](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/capitalize.html) which was deprecated in kotlin 1.5